### PR TITLE
Multisend: add warning for exceeding NFT send limit. App: add ToastContainer component to display toasts

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -26,6 +26,7 @@ import { useEffect } from 'react'
 import { useRouter } from 'next/router'
 
 import * as ga from '../lib/ga'
+import { ToastContainer } from 'react-toastify'
 
 // Default styles that can be overridden by your app
 require('@solana/wallet-adapter-react-ui/styles.css');
@@ -75,6 +76,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     <ConnectionProvider endpoint={endpoint}>
         <WalletProvider wallets={wallets} autoConnect>
             <WalletModalProvider>
+                <ToastContainer/>
                 <Component {...pageProps} />
             </WalletModalProvider>
         </WalletProvider>

--- a/pages/multisend.tsx
+++ b/pages/multisend.tsx
@@ -27,10 +27,18 @@ const MultiSend: NextPage = () => {
   const [search, setSearch] = useState('')
   const [loading, setLoading] = useState<boolean>(false)
 
+  if (sending.length > 7 ) {
+    toast(
+      `Warning! You may not be able to send ${sending.length} NFTs in one transaction. Send fewer NFTs to ensure success`,
+      {
+        toastId: 'TooManyNFTs',
+      })
+  }
+
   const massSend = async (list: Nft[], to: string) => {
     setLoading(true)
     if (to == '') {
-      toast.error('no dest')
+      toast.error('Destination wallet address is blank. Please enter a destination wallet')
       setLoading(false)
       return
     } else {


### PR DESCRIPTION
Hey Jason - I thought the Multi Send was a really helpful tool so I wanted to contribute! Let me know what you think - I'm very open to feedback. Thanks!

# Issue & Fix Summary
**Issue**: Transactions have a size limit of 1232 bytes. Therefore, there is a limit on the number of NFTs that can be sent using the `massSend` function within the `multisend` page. 

**Fix Summary**: Added a warning message (through the existing `react-toastify` package) to notify the user that the transaction may not succeed. The warning message is displayed if the user selects more than 7 NFTs to send. To display the warning message, also added the ToastContainer component inside of `_app.tsx`

# Fix Detail & Background
**Why was the threshold for the warning set at 7 NFTs?**

If the user is sending the NFTs to an wallet which had not previously held those exact same NFTs, then the Transaction size limit of 1232 bytes will only allow 7 NFTs to be sent. 

**Sending one NFT requires a total of 298 bytes**, composed of the transfer instruction and the create associated token account instruction.

**The [transfer instruction](https://github.com/solana-labs/solana-program-library/blob/024ba3ad410fef2d31e500c0f1a30db0c222a6a8/token/program-2022/src/instruction.rs#L119) requires 105 bytes**:
- 96 bytes for 3 accounts required: `fromTokenAccount`, `destTokenAccount`, `fromPublicKey`
- 1 byte for the `TokenInstruction::Transfer` instruction enum
- 8 bytes for the `amount` (u64)

**The [create ATA instruction](https://github.com/solana-labs/solana-program-library/blob/024ba3ad410fef2d31e500c0f1a30db0c222a6a8/associated-token-account/program/src/instruction.rs#L16) requires 193 bytes**
- 192 bytes for [six required accounts](https://github.com/solana-labs/solana-program-library/blob/024ba3ad410fef2d31e500c0f1a30db0c222a6a8/associated-token-account/program/src/instruction.rs#L19)
- 1 byte for the `AssociatedTokenAccountInstruction::Create` enum

**Sending subsequent NFTs (NFTs 2..n in the same transaction) requires 138 bytes, since several accounts inputs will be the same (same sender, same receiver)**

**Transfer**: 73 bytes => 105 bytes minus 32 bytes from one duplicated account key: `fromPublicKey`
**Create ATA**: 65 bytes => 193 bytes minus 128 bytes from 4 duplicated account keys: `fromPublicKey` `destPublicKey` `TOKEN_PROGRAM_ID` `ASSOCIATED_TOKEN_PROGRAM_ID` 

**Therefore, a transaction can hold a maximum of 7 NFT transfers, assuming the recipient had not held those NFTs previously:**
- 298 bytes (First NFT) + 6 * 138 bytes (Subsequent NFTs) => Transaction total size of 1126 bytes (limit = 1232)

**Notes**: 
- If all the NFTs being sent have been held by the recipient previously (aka the ATA already exists and does not need to be created), then the maximum number of NFTs that can be sent is sixteen. 105 bytes (First NFT) + 15 * 73 bytes (Subsequent NFTs). Because this maximum is higher than 7, I chose to emit a warning instead of not allowing the user to try sending the NFTs. But, I can see other reasonable approaches here too, so open to thoughts.
- The above math is mostly correct but I think I may be off by one or two bytes based on tests of the actual transaction size (sending 8 NFTs resulted in 1262 bytes instead of the predicted 1264 bytes). Haven't figured out the two byte difference yet :)

**Potential Next Step**: Create multiple transactions to handle the sending of any number of NFTs. Depending on the implementation, this could get fairly involved and since sending 7-16 at once is already pretty great for most use cases, the juice may not be worth the squeeze.
